### PR TITLE
fix: responsiveness of dorm tables on mobile 

### DIFF
--- a/src/components/DormCard.svelte
+++ b/src/components/DormCard.svelte
@@ -65,6 +65,16 @@
 		font-size: 0.9rem;
 	}
 
+	@media (max-width: 640px) {
+		.content {
+			grid-template-columns: repeat(2, 1fr);
+		}
+
+		.col:nth-child(2) {
+			border-right: none;
+		}
+	}
+
 	.col {
 		padding: 8px;
 		border-top: 1px solid black;


### PR DESCRIPTION
Fixes responsiveness by adapting based on the width of the screen (< 640px wide). 

fixes #23 