### PR TITLE
fix: morewood garden bed counts

### DIFF
--- a/src/data/dorms.ts
+++ b/src/data/dorms.ts
@@ -196,8 +196,8 @@ export const dorms: Dorm[] = [
 		],
 		info: [
 			"Semi-suite:",
-			"$14,994 Single (300 beds)",
-			"$12,916 Double (30 beds)",
+			"$14,994 Single (30 beds)",
+			"$12,916 Double (300 beds)",
 			"$11,700 Triple (93 beds)",
 			"Co-ed floors",
 			"Gender inclusive option",


### PR DESCRIPTION
The dorms page incorrectly stated that Morewood Gardens had
* "$14,994 Single (300 beds)"
* "$12,916 Double (30 beds)"
* "$11,700 Triple (93 beds)"

I updated this to reflect https://www.cmu.edu/housing/forms/26-27-housing-rates-non-staff.pdf
* "$14,994 Single (30 beds)"
* "$12,916 Double (300 beds)"
* "$11,700 Triple (93 beds)"